### PR TITLE
Mitigate safari background-repeat issue

### DIFF
--- a/app/components/HomePage/HomePageSalesContact/styles.css
+++ b/app/components/HomePage/HomePageSalesContact/styles.css
@@ -2,7 +2,10 @@
   display: flex;
   align-items: center;
   flex-direction: column;
-  background: linear-gradient(to right, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('static/img/flower-pattern-1.svg');
+  background-color: #072C2E;
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('static/img/flower-pattern-1.svg');
+  background-size: 50%;
+  background-repeat: repeat;
   padding: 120px;
   color: #F7DDC9;
 }


### PR DESCRIPTION
Safari has a rendering bug which renders a small gap between repeated backgrounds, showing the background color. This doesn't entirely fix it, but at least mitigates it a bit.