### PR TITLE
editorconfig: set insert_final_newline = true

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,6 @@ root = true
 
 [*]
 end_of_line = lf
-insert_final_newline = false
+insert_final_newline = true
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Since the linting yields errors when missing a final newline, it makes sense to configure editorconfig in this way. 