### PR TITLE
Support both iOS 11.2 and earlier for iPhone X styling

### DIFF
--- a/app/components/Cv/styles.css
+++ b/app/components/Cv/styles.css
@@ -9,10 +9,17 @@
   padding-bottom: env(safe-area-inset-bottom);
 }
 
-/* iPhone-X landscape insets */
-@supports (padding: max(0%)) {
+/* iPhone X landscape insets */
+@media only screen
+  and (device-width: 375px)
+  and (device-height: 812px)
+  and (-webkit-device-pixel-ratio: 3)
+  and (orientation: landscape) {
   .cv {
-    padding-right: max(25px, env(safe-area-inset-right));
+    /* stylelint-disable */
+    padding-right: constant(safe-area-inset-right);
+    padding-right: env(safe-area-inset-right);
+    /* stylelint-enable */
   }
 }
 

--- a/app/components/MemberListItem/styles.css
+++ b/app/components/MemberListItem/styles.css
@@ -9,9 +9,16 @@
 }
 
 /* iPhone-X landscape insets */
-@supports (padding: max(0%)) {
+@media only screen
+  and (device-width: 375px)
+  and (device-height: 812px)
+  and (-webkit-device-pixel-ratio: 3)
+  and (orientation: landscape) {
   .memberListItem {
-    padding-left: max(10px, env(safe-area-inset-left));
+    /* stylelint-disable */
+    padding-left: constant(safe-area-inset-left);
+    padding-left: env(safe-area-inset-left);
+    /* stylelint-enable */
   }
 }
 

--- a/app/containers/CvEdit/styles.css
+++ b/app/containers/CvEdit/styles.css
@@ -1,10 +1,23 @@
-.cvEdit { /* stylelint-disable */
+.cvEdit {
   padding-top: 46px;
+}
 
-  /* iPhone X landscape insets */
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-left);
-  padding-bottom: env(safe-area-inset-bottom);
+/* iPhone X landscape insets */
+@media only screen
+  and (device-width: 375px)
+  and (device-height: 812px)
+  and (-webkit-device-pixel-ratio: 3)
+  and (orientation: landscape) {
+  .cvEdit {
+    /* stylelint-disable */
+    padding-left: constant(safe-area-inset-left);
+    padding-right: constant(safe-area-inset-left);
+    padding-bottom: constant(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-left);
+    padding-bottom: env(safe-area-inset-bottom);
+    /* stylelint-enable */
+  }
 }
 
 .cvAction {

--- a/app/containers/Navbar/styles.css
+++ b/app/containers/Navbar/styles.css
@@ -12,10 +12,18 @@
 }
 
 /* iPhone-X landscape insets */
-@supports (padding: max(0%)) {
+@media only screen
+  and (device-width: 375px)
+  and (device-height: 812px)
+  and (-webkit-device-pixel-ratio: 3)
+  and (orientation: landscape) {
   .navbar {
-    padding-left: max(2em, env(safe-area-inset-left));
-    padding-right: max(2em, env(safe-area-inset-right));
+    /* stylelint-disable */
+    padding-left: constant(safe-area-inset-left);
+    padding-right: constant(safe-area-inset-right);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    /* stylelint-enable */
   }
 }
 

--- a/app/containers/Trip/styles.css
+++ b/app/containers/Trip/styles.css
@@ -1,25 +1,33 @@
-.trip { /* stylelint-disable */
+.trip {
   height: 100vh;
-  padding: 66px 20px 0 20px;
+  padding: 66px 20px 0;
   display: flex;
   flex-direction: column;
 }
 
 /* iPhone-X landscape insets */
-@supports (padding: max(0%)) {
+@media only screen
+  and (device-width: 375px)
+  and (device-height: 812px)
+  and (-webkit-device-pixel-ratio: 3)
+  and (orientation: landscape) {
   .trip {
-    padding-left: max(20px, env(safe-area-inset-left));
-    padding-right: max(20px, env(safe-area-inset-right));
+    /* stylelint-disable */
+    padding-left: constant(safe-area-inset-left);
+    padding-right: constant(safe-area-inset-right);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    /* stylelint-enable */
   }
 }
 
 .trip > h1 {
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 .trip > iframe {
   width: 100%;
-  flex:1;
+  flex: 1;
 }
 
 .trip .referral {


### PR DESCRIPTION
Need to use both `constant` and `env`. 
`max()` not supported pre 11.2.