### PR TITLE
Fix text capitalization on CV section headers

### DIFF
--- a/app/components/Cv/index.js
+++ b/app/components/Cv/index.js
@@ -27,8 +27,8 @@ function renderItem(item, i) {
 function renderSection(section) {
   const items = section.items.map((item, i) => renderItem(item, i))
   return (
-    <div key={section.title} className={styles.section} >
-      <h2>{section.title}</h2>
+    <div key={section.title} className={styles.section}>
+      <h2>{section.title.toLowerCase()}</h2>
       {items}
     </div>
   )

--- a/app/components/Cv/styles.css
+++ b/app/components/Cv/styles.css
@@ -36,6 +36,7 @@
 
 .section > h2 {
   border-bottom: 3px solid;
+  text-transform: capitalize;
 }
 
 .section .sectionInput {


### PR DESCRIPTION
Ensure that CV section headers are always capitalized as: `Capitalized Text Like This`.

`text-transform: capitalize` in css _only_ transforms the first letter to uppercase, it does _not_ transform the other letters to lowercase, so if a user has entered a title in all caps, it will still display as so. To circumvent this, we first transform the title to all lowercase, and then css-transform it to capitalized