### PR TITLE
fix hot reloading reducers

### DIFF
--- a/app/store.js
+++ b/app/store.js
@@ -34,6 +34,14 @@ export default function configureStore(initialState = {}, history) {
     compose(...enhancers)
   )
 
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('./reducers', () => {
+      const nextRootReducer = require('./reducers/index')
+      store.replaceReducer(nextRootReducer)
+    })
+  }
+
   return store
 }
 


### PR DESCRIPTION
The store broke when switching routes

Ref: [https://github.com/reactjs/react-redux/releases/tag/v2.0.0](https://github.com/reactjs/react-redux/releases/tag/v2.0.0)