### PR TITLE
Scroll to top on route changes

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 
 import styles from './styles.css'
 import Navbar from 'containers/Navbar'
+import ScrollContainer from 'containers/ScrollContainer'
 import * as actions from './actions'
 
 class App extends Component {
@@ -24,10 +25,12 @@ class App extends Component {
 
   render() {
     return (
-      <div className={styles.container}>
-        <Navbar />
-        { this.props.children }
-      </div>
+      <ScrollContainer>
+        <div className={styles.container}>
+          <Navbar />
+          { this.props.children }
+        </div>
+      </ScrollContainer>
     )
   }
 }

--- a/app/containers/ScrollContainer/index.js
+++ b/app/containers/ScrollContainer/index.js
@@ -1,0 +1,25 @@
+import { Component } from 'react'
+import PropTypes from 'prop-types'
+import { withRouter } from 'react-router-dom'
+
+class ScrollContainer extends Component {
+  componentDidUpdate(prevProps) {
+    // scroll to top when route changes,
+    // to ensure starting at the top of the page
+    // when clicking links
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0)
+    }
+  }
+
+  render() {
+    return this.props.children
+  }
+}
+
+ScrollContainer.propTypes = {
+  location: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+}
+
+export default withRouter(ScrollContainer)


### PR DESCRIPTION
scroll to top when route changes,
to ensure starting at the top of the page,
when clicking links

that almost sounds like a haiku